### PR TITLE
インストールするパッケージにruby-build追加

### DIFF
--- a/site-cookbooks/base/recipes/default.rb
+++ b/site-cookbooks/base/recipes/default.rb
@@ -9,7 +9,11 @@
 
 authorized_keys_for 'remper'
 
-%w{git rbenv bundler curl libxslt-dev libxml2-dev language-pack-ja-base}.each do |pkg|
+execute "apt-get update" do
+  user "root"
+end
+
+%w{git rbenv ruby-build bundler curl libxslt-dev libxml2-dev language-pack-ja-base}.each do |pkg|
   package pkg do
     action :install
   end


### PR DESCRIPTION
- rbenvで任意のバージョンのRubyをインストールできる様にruby-buildをパッケージに追加
