### PR TITLE
casto用不要コード定期削除cron追加

### DIFF
--- a/site-cookbooks/storyboards-app-base/recipes/default.rb
+++ b/site-cookbooks/storyboards-app-base/recipes/default.rb
@@ -27,3 +27,10 @@ cron "Site map generate" do
   minute "35"
 end
 
+cron "Casto temporary code erasing." do
+  user "remper"
+  command "cd ~/storyboards/current && bundle exec padrino rake codecleaner[2,1] -e production"
+  hour "5"
+  minute "35"
+end
+


### PR DESCRIPTION
### 解決したいこと
- [casto](http://ca.storyboards.jp) で作成された中身の無いコードモデルを定期的に削除するタスクを追加します。
