### PR TITLE
Casto登録コードの自動削除タスクの実行間隔修正

### DIFF
--- a/site-cookbooks/storyboards-app-base/recipes/default.rb
+++ b/site-cookbooks/storyboards-app-base/recipes/default.rb
@@ -29,8 +29,8 @@ end
 
 cron "Casto temporary code erasing." do
   user "remper"
-  command "cd ~/storyboards/current && bundle exec padrino rake codecleaner[2,1] -e production"
-  hour "5"
-  minute "35"
+  command "cd ~/storyboards/current && bundle exec padrino rake codecleaner -e production"
+  hour "*/1"
+  minute "30"
 end
 


### PR DESCRIPTION
### 解決したいこと
- storyboards001コンテナで動かしているCastoで登録されたコードの自動削除起動を1時間毎に変更します
