### PR TITLE
manage001, remp001 のRubyインストール方法修正

### DIFF
--- a/nodes/manage001.json
+++ b/nodes/manage001.json
@@ -1,1 +1,1 @@
-{"run_list":["base", "nodejs", "manage"]}
+{"run_list":["base", "ruby", "nodejs", "manage"]}

--- a/nodes/remp001.json
+++ b/nodes/remp001.json
@@ -1,1 +1,1 @@
-{"run_list":["base"]}
+{"run_list":["base", "ruby"]}


### PR DESCRIPTION
- `manage001` 及び `remp001` のRubyは `ruby` cook-book でインストールする様にします
