### PR TITLE
MongoDBバックアップスクリプトによるローカルファイルでの保管期間修正

### DIFF
--- a/site-cookbooks/mongo/files/default/mongodb_backup
+++ b/site-cookbooks/mongo/files/default/mongodb_backup
@@ -20,7 +20,7 @@ rm -rf $DUMP_DIR
 $DUMP_COMMAND -o $DUMP_DIR -d $DB_NAME
 
 # remove old file
-find $BACKUP_DIR -type f -mtime +30 | xargs rm -f
+find $BACKUP_DIR -type f -mtime +5 | xargs rm -f
 
 # compress
 tar vczPf $BACKUP_FILE $DUMP_DIR


### PR DESCRIPTION
`mongo001` コンテナ内でのバックアップファイルの保管期間を5日間に変更します
